### PR TITLE
chore(ci): add python ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     labels:
       - "dependencies"
       - "github_actions"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "python"


### PR DESCRIPTION
This PR adds the pip ecosystem to Dependabot to keep Python requirements up to date, and ensures pull requests are labeled correctly.