### PR TITLE
chore(deps): update dependencies and model

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -93,6 +93,7 @@ def allure_environment(
         f.writelines(f"{key}={value}\n" for key, value in env_props.items())
 
 
+
 @pytest.fixture
 async def llm() -> ChatGoogle:
     """Function-scoped fixture to initialize the language model."""

--- a/conftest.py
+++ b/conftest.py
@@ -96,7 +96,7 @@ def allure_environment(
 @pytest.fixture
 async def llm() -> ChatGoogle:
     """Function-scoped fixture to initialize the language model."""
-    DEFAULT_MODEL: str = "gemini-2.5-pro"
+    DEFAULT_MODEL: str = "gemini-3-flash-preview"
     model_name: str = os.getenv("GEMINI_MODEL", DEFAULT_MODEL)
     return ChatGoogle(
         model=model_name,

--- a/conftest.py
+++ b/conftest.py
@@ -29,6 +29,7 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 LLM_TEMPERATURE = 0.2
+DEFAULT_MODEL = "gemini-3-flash-preview"
 
 # --- Fixtures for Setup and Configuration ---
 
@@ -97,7 +98,6 @@ def allure_environment(
 @pytest.fixture
 async def llm() -> ChatGoogle:
     """Function-scoped fixture to initialize the language model."""
-    DEFAULT_MODEL: str = "gemini-3-flash-preview"
     model_name: str = os.getenv("GEMINI_MODEL", DEFAULT_MODEL)
     return ChatGoogle(
         model=model_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-allure_pytest==2.15.0
-browser_use[all]==0.8.0
-playwright==1.55.0
-pytest==8.4.2
-pytest_asyncio==1.2.0
-python_dotenv==1.1.1
-tenacity==8.5.0
+allure_pytest==2.15.3
+browser_use[all]==0.12.2
+playwright==1.58.0
+pytest==9.0.2
+pytest_asyncio==1.3.0
+python_dotenv==1.2.1
+tenacity==9.1.4


### PR DESCRIPTION
Uses pur to upgrade all requirements.txt dependencies to their latest versions, downgrades python_dotenv to 1.2.1 to resolve a dependency conflict with browser-use, and switches the default testing model to gemini-3-flash-preview.