### PR TITLE
ci: fix missing workflow permissions alert

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes missing workflow permissions by explicitly setting `permissions: contents: read` in the CI workflow, as recommended by CodeQL to limit GITHUB_TOKEN scope and enforce the principle of least privilege. Resolves CodeQL alert #1.