### PR TITLE
fix: upgrade to gemini-3.7-flash and pin CI to Flash-Lite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # This file is for local development and should not be committed to version control.
 
 # The specific Gemini model you want to use.
-GEMINI_MODEL="gemini-3.5-flash"
+GEMINI_MODEL="gemini-3.7-flash"
 
 # Your Google API key for accessing the Gemini model.
 GEMINI_API_KEY="YOUR_API_KEY"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run pytest
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # Pin CI a tier below the default model to keep these agentic browser
+          # runs cheap. The default stays gemini-3.7-flash for local runs.
+          GEMINI_MODEL: "gemini-3.5-flash-lite"
           HEADLESS: "true"
           BROWSER_USE_DISABLE_EXTENSIONS: "true"
           TIMEOUT_BrowserStartEvent: "120"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For more information on how to use Allure with pytest, see the [official Allure 
     * `GEMINI_API_KEY`: Your Google API key for accessing the Gemini model.
 
     **Optional Variables**:
-    * `GEMINI_MODEL`: The specific Gemini model you want to use (e.g., `gemini-3.5-flash`). For a list of available models, see the [Gemini models documentation](https://ai.google.dev/gemini-api/docs/models).
+    * `GEMINI_MODEL`: The specific Gemini model you want to use (e.g., `gemini-3.7-flash`). For a list of available models, see the [Gemini models documentation](https://ai.google.dev/gemini-api/docs/models).
     * `HEADLESS`: Set to `true` to run in headless mode (without a visible browser UI) or `false` to run with a visible UI.
     * `BROWSER_USE_DISABLE_EXTENSIONS`: Set to `true` to disable default extensions loaded by `browser-use` (e.g., uBlock Origin). This is highly recommended in headless CI environments to prevent startup timeouts/deadlocks.
 

--- a/conftest.py
+++ b/conftest.py
@@ -29,8 +29,7 @@ if TYPE_CHECKING:
 load_dotenv()
 logger = logging.getLogger(__name__)
 
-LLM_TEMPERATURE = 0.2
-DEFAULT_MODEL = "gemini-3.5-flash"
+DEFAULT_MODEL = "gemini-3.7-flash"
 
 # --- Fixtures for Setup and Configuration ---
 
@@ -102,7 +101,6 @@ async def llm() -> ChatGoogle:
     model_name: str = os.getenv("GEMINI_MODEL", DEFAULT_MODEL)
     return ChatGoogle(
         model=model_name,
-        temperature=LLM_TEMPERATURE,
         api_key=os.getenv("GEMINI_API_KEY"),
     )
 


### PR DESCRIPTION
## What

Three related changes.

### 1. Model upgrade

`gemini-3.5-flash` → `gemini-3.7-flash` in `conftest.py`, `.env.example` and the README.

### 2. Removed a dead `temperature`

`conftest.py` passed `temperature=0.2` to `ChatGoogle`. Gemini 3.x **accepts `temperature`, `top_p` and `top_k` but silently ignores them** — no error, no warning — so this already had no effect on the running model. Google has indicated future generations will reject these parameters outright rather than ignore them.

The `LLM_TEMPERATURE` constant went with it since nothing else referenced it.

### 3. CI pinned to Flash-Lite

These are agentic browser tests driving a real model against a live site, which makes them the most expensive suite to run per push. `run-tests.yml` now sets `GEMINI_MODEL: gemini-3.5-flash-lite`. Local runs keep the `gemini-3.7-flash` default.

## Verification

Pinning CI to a cheaper tier is the change that could plausibly break this suite, so it was tested directly rather than left for CI to discover:

- **All 8 tests pass on `gemini-3.5-flash-lite`** (139s), including the search cases that need multi-step interaction with the search overlay.
- Sanity run on the new `gemini-3.7-flash` default: passes.
- `ChatGoogle` constructs cleanly without `temperature`; the parameter defaults to `None` and is simply not sent.

## Notes

If Flash-Lite ever turns out to be too weak for a future test, dropping the `GEMINI_MODEL` line from `run-tests.yml` reverts CI to the `gemini-3.7-flash` default with no other changes.
